### PR TITLE
Use replace instead of set

### DIFF
--- a/lib/arrays.ex
+++ b/lib/arrays.ex
@@ -42,8 +42,8 @@ defmodule Arrays do
   @spec get(array, index) :: any
   defdelegate get(array, index), to: Arrays.Protocol
 
-  @spec set(array, index, value :: any) :: array
-  defdelegate set(array, index, value), to: Arrays.Protocol
+  @spec replace(array, index, value :: any) :: array
+  defdelegate replace(array, index, value), to: Arrays.Protocol
 
   @spec reset(array, index) :: any
   defdelegate reset(array, index), to: Arrays.Protocol

--- a/lib/arrays/implementations/erlang_array.ex
+++ b/lib/arrays/implementations/erlang_array.ex
@@ -126,6 +126,8 @@ defmodule Arrays.Implementations.ErlangArray do
       end
     end
 
+    defdelegate replace(array, index, element), to: __MODULE__, as: :set
+
     def set(array = %ErlangArray{contents: contents}, index, item) do
       new_contents =
         if index < 0 do

--- a/lib/arrays/implementations/map_array.ex
+++ b/lib/arrays/implementations/map_array.ex
@@ -133,13 +133,13 @@ defmodule Arrays.Implementations.MapArray do
       contents[index + map_size(contents)]
     end
 
-    def set(array = %MapArray{contents: contents}, index, value)
+    def replace(array = %MapArray{contents: contents}, index, value)
         when index >= 0 and index < map_size(contents) do
       new_contents = Map.put(contents, index, value)
       %MapArray{array | contents: new_contents}
     end
 
-    def set(array = %MapArray{contents: contents}, index, value)
+    def replace(array = %MapArray{contents: contents}, index, value)
         when index < 0 and index >= -map_size(contents) do
       new_contents = Map.put(contents, index + map_size(contents), value)
       %MapArray{array | contents: new_contents}

--- a/lib/arrays/protocol.ex
+++ b/lib/arrays/protocol.ex
@@ -20,8 +20,8 @@ defprotocol Arrays.Protocol do
   @spec get(array, index) :: any
   def get(array, index)
 
-  @spec set(array, index, item :: any) :: array
-  def set(array, index, item)
+  @spec replace(array, index, item :: any) :: array
+  def replace(array, index, item)
 
   @spec reset(array, index) :: any
   def reset(array, index)


### PR DESCRIPTION
It is idiomatic to Elixir the name replace, instead of set.