### PR TITLE
Remove Arrays.Behaviour and move callbacks inside protocol

### DIFF
--- a/lib/arrays/behaviour.ex
+++ b/lib/arrays/behaviour.ex
@@ -1,5 +1,0 @@
-defmodule Arrays.Behaviour do
-  @type option :: {:default, any} | {atom, any}
-  @type options :: [option]
-  @callback empty(options) :: Arrays.Protocol.t()
-end

--- a/lib/arrays/implementations/erlang_array.ex
+++ b/lib/arrays/implementations/erlang_array.ex
@@ -8,12 +8,6 @@ defmodule Arrays.Implementations.ErlangArray do
   """
   defstruct [:contents]
 
-  # {:default, val} and {:size, num} are forwarded to `:array`
-  def empty(options) do
-    contents = :array.new([{:fixed, false} | options] ++ [default: nil])
-    %ErlangArray{contents: contents}
-  end
-
   use FunLand.Mappable
 
   def map(array = %ErlangArray{contents: contents}, fun) do
@@ -96,27 +90,40 @@ defmodule Arrays.Implementations.ErlangArray do
   defimpl Arrays.Protocol do
     alias Arrays.Implementations.ErlangArray
 
+    @impl true
+    # {:default, val} and {:size, num} are forwarded to `:array`
+    def empty(options) do
+      contents = :array.new([{:fixed, false} | options] ++ [default: nil])
+      %ErlangArray{contents: contents}
+    end
+
+    @impl true
     def size(%ErlangArray{contents: contents}) do
       :array.size(contents)
     end
 
+    @impl true
     def map(array = %ErlangArray{contents: contents}, fun) do
       new_contents = :array.map(fun, contents)
       %ErlangArray{array | contents: new_contents}
     end
 
+    @impl true
     def reduce(%ErlangArray{contents: contents}, acc, fun) do
       :array.foldl(fun, acc, contents)
     end
 
+    @impl true
     def reduce_right(%ErlangArray{contents: contents}, acc, fun) do
       :array.foldr(fun, acc, contents)
     end
 
+    @impl true
     def default(%ErlangArray{contents: contents}) do
       :array.default(contents)
     end
 
+    @impl true
     def get(%ErlangArray{contents: contents}, index) do
       if index < 0 do
         :array.get(contents, index + :array.size(contents))
@@ -125,6 +132,7 @@ defmodule Arrays.Implementations.ErlangArray do
       end
     end
 
+    @impl true
     defdelegate replace(array, index, element), to: __MODULE__, as: :set
 
     def set(array = %ErlangArray{contents: contents}, index, item) do
@@ -138,6 +146,7 @@ defmodule Arrays.Implementations.ErlangArray do
       %ErlangArray{array | contents: new_contents}
     end
 
+    @impl true
     def reset(array = %ErlangArray{contents: contents}, index) do
       new_contents =
         if index < 0 do
@@ -149,16 +158,19 @@ defmodule Arrays.Implementations.ErlangArray do
       %ErlangArray{array | contents: new_contents}
     end
 
+    @impl true
     def append(array = %ErlangArray{contents: contents}, item) do
       new_contents = :array.set(:array.size(contents), item, contents)
       %ErlangArray{array | contents: new_contents}
     end
 
+    @impl true
     def resize(array = %ErlangArray{contents: contents}, new_size) do
       new_contents = :array.resize(contents, new_size)
       %ErlangArray{array | contents: new_contents}
     end
 
+    @impl true
     def extract(array = %ErlangArray{contents: contents}) do
       case :array.size(contents) do
         0 ->
@@ -173,6 +185,7 @@ defmodule Arrays.Implementations.ErlangArray do
       end
     end
 
+    @impl true
     def to_list(%ErlangArray{contents: contents}) do
       :array.to_list(contents)
     end

--- a/lib/arrays/implementations/map_array.ex
+++ b/lib/arrays/implementations/map_array.ex
@@ -6,19 +6,9 @@ defmodule Arrays.Implementations.MapArray do
   """
   defstruct contents: %{}, default: nil
 
-  def empty(options) do
-    default = Keyword.get(options, :default, nil)
-    size = Keyword.get(options, :size, 0)
-    %MapArray{contents: construct(default, size), default: default}
-  end
-
-  defp construct(_default, 0), do: %{}
-
-  defp construct(default, size) do
-    Enum.into(0..(size - 1), %{}, &{&1, default})
-  end
-
   use FunLand.Mappable
+
+  defdelegate empty(option \\ []), to: Arrays.Protocol.Arrays.Implementations.MapArray
 
   def map(array = %MapArray{contents: contents}, fun) do
     %MapArray{array | contents: :maps.map(fun, contents)}
@@ -89,15 +79,31 @@ defmodule Arrays.Implementations.MapArray do
   defimpl Arrays.Protocol do
     alias Arrays.Implementations.MapArray
 
+    @impl true
+    def empty(options) do
+      default = Keyword.get(options, :default, nil)
+      size = Keyword.get(options, :size, 0)
+      %MapArray{contents: construct(default, size), default: default}
+    end
+
+    defp construct(_default, 0), do: %{}
+
+    defp construct(default, size) do
+      Enum.into(0..(size - 1), %{}, &{&1, default})
+    end
+
+    @impl true
     def size(%MapArray{contents: contents}) do
       map_size(contents)
     end
 
+    @impl true
     def map(array = %MapArray{contents: contents}, fun) do
       new_contents = :maps.map(fun, contents)
       %MapArray{array | contents: new_contents}
     end
 
+    @impl true
     def reduce(%MapArray{contents: contents}, acc, fun) do
       reduce(contents, acc, fun, 0, :maps.size(contents))
     end
@@ -108,6 +114,7 @@ defmodule Arrays.Implementations.MapArray do
       reduce(contents, fun.(contents[index], acc), fun, index + 1, max_index)
     end
 
+    @impl true
     def reduce_right(%MapArray{contents: contents}, acc, fun) do
       reduce_right(contents, acc, fun, :maps.size(contents))
     end
@@ -118,10 +125,12 @@ defmodule Arrays.Implementations.MapArray do
       reduce_right(contents, fun.(contents[index], acc), fun, index - 1)
     end
 
+    @impl true
     def default(%MapArray{default: default}) do
       default
     end
 
+    @impl true
     def get(%MapArray{contents: contents}, index)
         when index >= 0 and index < map_size(contents) do
       contents[index]
@@ -132,6 +141,7 @@ defmodule Arrays.Implementations.MapArray do
       contents[index + map_size(contents)]
     end
 
+    @impl true
     def replace(array = %MapArray{contents: contents}, index, value)
         when index >= 0 and index < map_size(contents) do
       new_contents = Map.put(contents, index, value)
@@ -144,23 +154,27 @@ defmodule Arrays.Implementations.MapArray do
       %MapArray{array | contents: new_contents}
     end
 
+    @impl true
     def reset(array = %MapArray{contents: contents, default: default}, index)
         when index >= 0 and index < map_size(contents) do
       new_contents = Map.put(contents, index, default)
       %MapArray{array | contents: new_contents}
     end
 
+    @impl true
     def reset(array = %MapArray{contents: contents, default: default}, index)
         when index < 0 and index >= -map_size(contents) do
       new_contents = Map.put(contents, index + map_size(contents), default)
       %MapArray{array | contents: new_contents}
     end
 
+    @impl true
     def append(array = %MapArray{contents: contents}, value) do
       new_contents = Map.put(contents, map_size(contents), value)
       %MapArray{array | contents: new_contents}
     end
 
+    @impl true
     def resize(%MapArray{default: default}, 0) do
       MapArray.empty(default: default)
     end
@@ -183,6 +197,7 @@ defmodule Arrays.Implementations.MapArray do
       %MapArray{array | contents: new_contents}
     end
 
+    @impl true
     def extract(array = %MapArray{contents: contents}) when map_size(contents) > 0 do
       index = map_size(contents) - 1
       elem = contents[index]
@@ -195,6 +210,7 @@ defmodule Arrays.Implementations.MapArray do
       {:error, :empty}
     end
 
+    @impl true
     def to_list(%MapArray{contents: contents}) do
       :maps.values(contents)
     end

--- a/lib/arrays/protocol.ex
+++ b/lib/arrays/protocol.ex
@@ -2,6 +2,10 @@ defprotocol Arrays.Protocol do
   @type array :: t
   @type index :: integer
   @type value :: any
+  @type option :: {:default, any} | {atom, any}
+  @type options :: [option]
+
+  @callback empty(options) :: t()
 
   @spec size(array) :: non_neg_integer
   def size(array)


### PR DESCRIPTION
Different approach to #31. It closes #25

I like this approach better as we don't need to declare in the implementation the behaviour that we are using.